### PR TITLE
fix: Trying to get property 'ID' of non-object

### DIFF
--- a/class-toc-plus.php
+++ b/class-toc-plus.php
@@ -1624,6 +1624,11 @@ if ( ! class_exists( 'toc_widget' ) ) :
 		 */
 		function widget( $args, $instance ) {
 			global $toc_plus, $wp_query;
+
+            if ($wp_query->post === NULL) {
+                return;
+            }
+
 			$items               = '';
 			$custom_toc_position = '';
 			$find                = [];


### PR DESCRIPTION
When using TOC in a widget, post may not always be defined. To avoid a php error the plugin should abort in time.