### PR TITLE
Update class-toc-plus.php

### DIFF
--- a/class-toc-plus.php
+++ b/class-toc-plus.php
@@ -1341,6 +1341,10 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 			$this->collision_collector = [];
 
 			if ( is_array( $find ) && is_array( $replace ) && $content ) {
+				
+				// filter the content
+				$content = apply_filters( 'toc_url_extract_heading_content', $content );
+				
 				// get all headings
 				// the html spec allows for a maximum of 6 heading depths
 				if ( preg_match_all( '/(<h([1-6]{1})[^>]*>).*<\/h\2>/msuU', $content, $matches, PREG_SET_ORDER ) ) {


### PR DESCRIPTION
Add filter for content in extract_headings function

The main goal is to be able to make this Table of Content Plus plugin widget compatible with some translation plugin like qtranslate-xt, for which I currently have to add in class-toc-plus.php (where I propose the filter):

```php
/* X-Raym Mod for qtranslate support */
if( function_exists( "qtranxf_useCurrentLanguageIfNotFoundShowEmpty" ) ) {
	$content =  qtranxf_useCurrentLanguageIfNotFoundShowEmpty( $content );
}
```

(the widget currently display the two language at the same time).

Also, this could maybe be used by others for some things like

- https://github.com/zedzedzed/table-of-contents-plus/issues/148
- https://github.com/zedzedzed/table-of-contents-plus/issues/128