### PR TITLE
Implements sub-menus [sitemap_pages child_of="current"] and [sitemap_pages child_of="1234"]

### DIFF
--- a/class-toc-plus.php
+++ b/class-toc-plus.php
@@ -326,6 +326,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 
 		public function shortcode_sitemap_pages( $attributes ) {
 			global $post;
+			$args_child_of = 0;
 			$atts = shortcode_atts(
 				[
 					'heading'      => $this->options['sitemap_heading_type'],
@@ -338,14 +339,21 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 				$attributes
 			);
 
+			// -- debugging
+			//echo 'debug: child_of:   ' . $child_of . ' ' . "\n";    // true
+			//echo 'debug: current ID: ' . $post->ID . ' end ' . "\n";  // 2311
+
+
 			$atts['heading'] = intval( $atts['heading'] );  // make sure it's an integer
 
 			if ( $atts['heading'] < 1 || $atts['heading'] > 6 ) {  // h1 to h6 are valid
 				$atts['heading'] = $this->options['sitemap_heading_type'];
 			}
 
+
+
 			// -- [ sitemap_pages child_of="current" ]
-			if ( $child_of == "current" ) {
+			if ( $atts['child_of'] == "current" ) {
 				$args_child_of = $post->ID;
 			}
 			else if ( is_numeric($child_of) ) {
@@ -354,6 +362,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 			} else {
 				//$child_of = 0;
 			}
+			//echo "debug: intval args_child_of:" . intval($args_child_of) . "\n";
 
 			$html = '<div class="toc_sitemap">';
 			if ( ! $atts['no_label'] ) {
@@ -368,7 +377,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 								'exclude'      => $atts['exclude'],
 								'exclude_tree' => $atts['exclude_tree'],
 								'hierarchical' => true,
-								'child_of' => $args_child_of
+								'child_of' =>  intval($args_child_of)   // 1017 must be integer here
 							]
 						) .
 					'</ul>' .

--- a/class-toc-plus.php
+++ b/class-toc-plus.php
@@ -325,6 +325,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 
 
 		public function shortcode_sitemap_pages( $attributes ) {
+			global $post;
 			$atts = shortcode_atts(
 				[
 					'heading'      => $this->options['sitemap_heading_type'],
@@ -332,6 +333,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 					'no_label'     => false,
 					'exclude'      => '',
 					'exclude_tree' => '',
+					'child_of'     => $this->options['child_of']
 				],
 				$attributes
 			);
@@ -340,6 +342,17 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 
 			if ( $atts['heading'] < 1 || $atts['heading'] > 6 ) {  // h1 to h6 are valid
 				$atts['heading'] = $this->options['sitemap_heading_type'];
+			}
+
+			// -- [ sitemap_pages child_of="current" ]
+			if ( $child_of == "current" ) {
+				$args_child_of = $post->ID;
+			}
+			else if ( is_numeric($child_of) ) {
+				// -- [ sitemap_pages child_of="1234" ]
+				$args_child_of = $child_of;
+			} else {
+				//$child_of = 0;
 			}
 
 			$html = '<div class="toc_sitemap">';
@@ -354,6 +367,8 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 								'echo'         => false,
 								'exclude'      => $atts['exclude'],
 								'exclude_tree' => $atts['exclude_tree'],
+								'hierarchical' => true,
+								'child_of' => $args_child_of
 							]
 						) .
 					'</ul>' .

--- a/class-toc-plus.php
+++ b/class-toc-plus.php
@@ -325,8 +325,6 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 
 
 		public function shortcode_sitemap_pages( $attributes ) {
-			global $post;
-			$args_child_of = 0;
 			$atts = shortcode_atts(
 				[
 					'heading'      => $this->options['sitemap_heading_type'],
@@ -334,15 +332,10 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 					'no_label'     => false,
 					'exclude'      => '',
 					'exclude_tree' => '',
-					'child_of'     => $this->options['child_of']
+					'child_of'     => 0,
 				],
 				$attributes
 			);
-
-			// -- debugging
-			//echo 'debug: child_of:   ' . $child_of . ' ' . "\n";    // true
-			//echo 'debug: current ID: ' . $post->ID . ' end ' . "\n";  // 2311
-
 
 			$atts['heading'] = intval( $atts['heading'] );  // make sure it's an integer
 
@@ -350,19 +343,13 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 				$atts['heading'] = $this->options['sitemap_heading_type'];
 			}
 
-
-
-			// -- [ sitemap_pages child_of="current" ]
-			if ( $atts['child_of'] == "current" ) {
-				$args_child_of = $post->ID;
-			}
-			else if ( is_numeric($child_of) ) {
-				// -- [ sitemap_pages child_of="1234" ]
-				$args_child_of = $child_of;
+			if ( strtolower( $atts['child_of'] ) === "current" ) {
+				$atts['child_of'] = get_the_ID();
+			} elseif ( is_numeric( $atts['child_of'] ) ) {
+				$atts['child_of'] = intval( $atts['child_of'] );
 			} else {
-				//$child_of = 0;
+				$atts['child_of'] = 0;
 			}
-			//echo "debug: intval args_child_of:" . intval($args_child_of) . "\n";
 
 			$html = '<div class="toc_sitemap">';
 			if ( ! $atts['no_label'] ) {
@@ -377,7 +364,7 @@ if ( ! class_exists( 'TOC_Plus' ) ) :
 								'exclude'      => $atts['exclude'],
 								'exclude_tree' => $atts['exclude_tree'],
 								'hierarchical' => true,
-								'child_of' =>  intval($args_child_of)   // 1017 must be integer here
+								'child_of'     => $atts['child_of'],
 							]
 						) .
 					'</ul>' .


### PR DESCRIPTION
Implements sub-menus [sitemap_pages child_of="current"] and [sitemap_pages child_of="1234"]
status:works with php 8.2 and WordPress 6.3

Just place 
  [sitemap_pages child_of="current"]
within a page to display sub-menu of current page.

Or
  [sitemap_pages child_of="1234"]
for sub-menus of a sub-menu, for example for footers.

